### PR TITLE
A few refactors

### DIFF
--- a/packages/runtime/src/cross/model-meta.ts
+++ b/packages/runtime/src/cross/model-meta.ts
@@ -1,17 +1,17 @@
 import { lowerCaseFirst } from 'lower-case-first';
 
 /**
- * An access key in the user context object (e.g. `profile.picture.url`)
- */
-export type AuthContextSelector = string;
-
-/**
  * Runtime information of a data model or field attribute
  */
 export type RuntimeAttribute = {
     name: string;
-    args: Array<{ name?: string; value: unknown } | { name: 'auth()'; value: AuthContextSelector }>;
+    args: Array<{ name?: string; value: unknown }>;
 };
+
+/**
+ * Function for computing default value for a field
+ */
+export type FieldDefaultValueProvider = (userContext: unknown) => unknown;
 
 /**
  * Runtime information of a data model field
@@ -71,6 +71,11 @@ export type FieldInfo = {
      * Mapping from foreign key field names to relation field names
      */
     foreignKeyMapping?: Record<string, string>;
+
+    /**
+     * A function that provides a default value for the field
+     */
+    defaultValueProvider?: FieldDefaultValueProvider;
 };
 
 /**

--- a/packages/runtime/src/enhancements/create-enhancement.ts
+++ b/packages/runtime/src/enhancements/create-enhancement.ts
@@ -132,9 +132,7 @@ export function createEnhancement<DbClient extends object>(
         const allFields = Object.values(options.modelMeta.fields).flatMap((modelInfo) => Object.values(modelInfo));
         hasPassword = allFields.some((field) => field.attributes?.some((attr) => attr.name === '@password'));
         hasOmit = allFields.some((field) => field.attributes?.some((attr) => attr.name === '@omit'));
-        hasDefaultAuth = allFields.some((field) =>
-            field.attributes?.some((attr) => attr.name === '@default' && attr.args[0]?.name === 'auth()')
-        );
+        hasDefaultAuth = allFields.some((field) => field.defaultValueProvider);
     }
 
     const kinds = options.kinds ?? [

--- a/packages/runtime/src/enhancements/default-auth.ts
+++ b/packages/runtime/src/enhancements/default-auth.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import deepcopy from 'deepcopy';
 import { FieldInfo, NestedWriteVisitor, PrismaWriteActionType, enumerate, getFields } from '../cross';
 import { DbClientContract } from '../types';
 import { EnhancementContext, EnhancementOptions } from './create-enhancement';
@@ -48,12 +49,15 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
     protected async preprocessArgs(action: PrismaProxyActions, args: any) {
         const actionsOfInterest: PrismaProxyActions[] = ['create', 'createMany', 'update', 'updateMany', 'upsert'];
         if (actionsOfInterest.includes(action)) {
-            await this.preprocessWritePayload(this.model, action as PrismaWriteActionType, args);
+            const newArgs = await this.preprocessWritePayload(this.model, action as PrismaWriteActionType, args);
+            return newArgs;
         }
         return args;
     }
 
     private async preprocessWritePayload(model: string, action: PrismaWriteActionType, args: any) {
+        const newArgs = deepcopy(args);
+
         const processCreatePayload = (model: string, data: any) => {
             const fields = getFields(this.options.modelMeta, model);
             for (const fieldInfo of Object.values(fields)) {
@@ -88,7 +92,8 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
             },
         });
 
-        await visitor.visit(model, action, args);
+        await visitor.visit(model, action, newArgs);
+        return newArgs;
     }
 
     private getDefaultValueFromAuth(fieldInfo: FieldInfo) {

--- a/packages/runtime/src/enhancements/default-auth.ts
+++ b/packages/runtime/src/enhancements/default-auth.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import deepcopy from 'deepcopy';
 import { FieldInfo, NestedWriteVisitor, PrismaWriteActionType, enumerate, getFields } from '../cross';
 import { DbClientContract } from '../types';
 import { EnhancementContext, EnhancementOptions } from './create-enhancement';
@@ -49,15 +48,12 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
     protected async preprocessArgs(action: PrismaProxyActions, args: any) {
         const actionsOfInterest: PrismaProxyActions[] = ['create', 'createMany', 'update', 'updateMany', 'upsert'];
         if (actionsOfInterest.includes(action)) {
-            const newArgs = await this.preprocessWritePayload(this.model, action as PrismaWriteActionType, args);
-            return newArgs;
+            await this.preprocessWritePayload(this.model, action as PrismaWriteActionType, args);
         }
         return args;
     }
 
     private async preprocessWritePayload(model: string, action: PrismaWriteActionType, args: any) {
-        const newArgs = deepcopy(args);
-
         const processCreatePayload = (model: string, data: any) => {
             const fields = getFields(this.options.modelMeta, model);
             for (const fieldInfo of Object.values(fields)) {
@@ -92,8 +88,7 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
             },
         });
 
-        await visitor.visit(model, action, newArgs);
-        return newArgs;
+        await visitor.visit(model, action, args);
     }
 
     private getDefaultValueFromAuth(fieldInfo: FieldInfo) {

--- a/packages/schema/src/language-server/validator/function-invocation-validator.ts
+++ b/packages/schema/src/language-server/validator/function-invocation-validator.ts
@@ -11,10 +11,15 @@ import {
     isDataModelFieldAttribute,
     isLiteralExpr,
 } from '@zenstackhq/language/ast';
-import { ExpressionContext, getFunctionExpressionContext, isEnumFieldReference, isFromStdlib } from '@zenstackhq/sdk';
+import {
+    ExpressionContext,
+    getDataModelFieldReference,
+    getFunctionExpressionContext,
+    isEnumFieldReference,
+    isFromStdlib,
+} from '@zenstackhq/sdk';
 import { AstNode, ValidationAcceptor } from 'langium';
 import { P, match } from 'ts-pattern';
-import { getDataModelFieldReference } from '../../utils/ast-utils';
 import { AstValidator } from '../types';
 import { typeAssignable } from './utils';
 

--- a/packages/schema/src/language-server/zmodel-linker.ts
+++ b/packages/schema/src/language-server/zmodel-linker.ts
@@ -35,7 +35,7 @@ import {
     isReferenceExpr,
     isStringLiteral,
 } from '@zenstackhq/language/ast';
-import { getContainingModel, hasAttribute, isFromStdlib } from '@zenstackhq/sdk';
+import { getContainingModel, hasAttribute, isAuthInvocation, isFutureExpr } from '@zenstackhq/sdk';
 import {
     AstNode,
     AstNodeDescription,
@@ -52,12 +52,7 @@ import {
 } from 'langium';
 import { match } from 'ts-pattern';
 import { CancellationToken } from 'vscode-jsonrpc';
-import {
-    getAllDeclarationsFromImports,
-    getContainingDataModel,
-    isAuthInvocation,
-    isCollectionPredicate,
-} from '../utils/ast-utils';
+import { getAllDeclarationsFromImports, getContainingDataModel, isCollectionPredicate } from '../utils/ast-utils';
 import { mapBuiltinTypeToExpressionType } from './validator/utils';
 
 interface DefaultReference extends Reference {
@@ -329,7 +324,7 @@ export class ZModelLinker extends DefaultLinker {
         if (node.function.ref) {
             // eslint-disable-next-line @typescript-eslint/ban-types
             const funcDecl = node.function.ref as FunctionDecl;
-            if (funcDecl.name === 'auth' && isFromStdlib(funcDecl)) {
+            if (isAuthInvocation(node)) {
                 // auth() function is resolved to User model in the current document
                 const model = getContainingModel(node);
 
@@ -346,7 +341,7 @@ export class ZModelLinker extends DefaultLinker {
                         node.$resolvedType = { decl: authModel, nullable: true };
                     }
                 }
-            } else if (funcDecl.name === 'future' && isFromStdlib(funcDecl)) {
+            } else if (isFutureExpr(node)) {
                 // future() function is resolved to current model
                 node.$resolvedType = { decl: getContainingDataModel(node) };
             } else {

--- a/packages/schema/src/plugins/enhancer/policy/expression-writer.ts
+++ b/packages/schema/src/plugins/enhancer/policy/expression-writer.ts
@@ -19,19 +19,18 @@ import {
 import {
     ExpressionContext,
     getFunctionExpressionContext,
+    getIdFields,
     getLiteral,
+    isAuthInvocation,
     isDataModelFieldReference,
     isFutureExpr,
     PluginError,
+    TypeScriptExpressionTransformer,
+    TypeScriptExpressionTransformerError,
 } from '@zenstackhq/sdk';
 import { lowerCaseFirst } from 'lower-case-first';
 import { CodeBlockWriter } from 'ts-morph';
 import { name } from '..';
-import { getIdFields, isAuthInvocation } from '../../../utils/ast-utils';
-import {
-    TypeScriptExpressionTransformer,
-    TypeScriptExpressionTransformerError,
-} from '../../../utils/typescript-expression-transformer';
 
 type ComparisonOperator = '==' | '!=' | '>' | '>=' | '<' | '<=';
 

--- a/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
+++ b/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
@@ -33,14 +33,18 @@ import {
     PluginError,
     PluginOptions,
     RUNTIME_PACKAGE,
+    TypeScriptExpressionTransformer,
+    TypeScriptExpressionTransformerError,
     analyzePolicies,
     getAttributeArg,
     getAuthModel,
     getDataModels,
+    getIdFields,
     getLiteral,
     getPrismaClientImportSpec,
     hasAttribute,
     hasValidationAttributes,
+    isAuthInvocation,
     isEnumFieldReference,
     isForeignKeyField,
     isFromStdlib,
@@ -52,11 +56,7 @@ import { lowerCaseFirst } from 'lower-case-first';
 import path from 'path';
 import { FunctionDeclaration, Project, SourceFile, VariableDeclarationKind, WriterFunction } from 'ts-morph';
 import { name } from '..';
-import { getIdFields, isAuthInvocation, isCollectionPredicate } from '../../../utils/ast-utils';
-import {
-    TypeScriptExpressionTransformer,
-    TypeScriptExpressionTransformerError,
-} from '../../../utils/typescript-expression-transformer';
+import { isCollectionPredicate } from '../../../utils/ast-utils';
 import { ALL_OPERATION_KINDS } from '../../plugin-utils';
 import { ExpressionWriter, FALSE, TRUE } from './expression-writer';
 

--- a/packages/schema/src/plugins/zod/utils/schema-gen.ts
+++ b/packages/schema/src/plugins/zod/utils/schema-gen.ts
@@ -1,6 +1,8 @@
 import {
     ExpressionContext,
     PluginError,
+    TypeScriptExpressionTransformer,
+    TypeScriptExpressionTransformerError,
     getAttributeArg,
     getAttributeArgLiteral,
     getLiteral,
@@ -18,10 +20,6 @@ import {
 } from '@zenstackhq/sdk/ast';
 import { upperCaseFirst } from 'upper-case-first';
 import { name } from '..';
-import {
-    TypeScriptExpressionTransformer,
-    TypeScriptExpressionTransformerError,
-} from '../../../utils/typescript-expression-transformer';
 
 export function makeFieldSchema(field: DataModelField, respectDefault = false) {
     if (isDataModel(field.type.reference?.ref)) {

--- a/packages/schema/src/utils/ast-utils.ts
+++ b/packages/schema/src/utils/ast-utils.ts
@@ -1,21 +1,13 @@
 import {
     BinaryExpr,
     DataModel,
-    DataModelField,
     Expression,
-    isArrayExpr,
     isBinaryExpr,
     isDataModel,
-    isDataModelField,
-    isInvocationExpr,
-    isMemberAccessExpr,
     isModel,
-    isReferenceExpr,
     Model,
     ModelImport,
-    ReferenceExpr,
 } from '@zenstackhq/language/ast';
-import { isFromStdlib } from '@zenstackhq/sdk';
 import { AstNode, getDocument, LangiumDocuments, Mutable } from 'langium';
 import { URI, Utils } from 'vscode-uri';
 
@@ -54,43 +46,6 @@ function updateContainer<T extends AstNode>(nodes: T[], container: AstNode): Mut
         mutable.$container = container;
         return mutable;
     });
-}
-
-export function getIdFields(dataModel: DataModel) {
-    const fieldLevelId = dataModel.$resolvedFields.find((f) =>
-        f.attributes.some((attr) => attr.decl.$refText === '@id')
-    );
-    if (fieldLevelId) {
-        return [fieldLevelId];
-    } else {
-        // get model level @@id attribute
-        const modelIdAttr = dataModel.attributes.find((attr) => attr.decl?.ref?.name === '@@id');
-        if (modelIdAttr) {
-            // get fields referenced in the attribute: @@id([field1, field2]])
-            if (!isArrayExpr(modelIdAttr.args[0].value)) {
-                return [];
-            }
-            const argValue = modelIdAttr.args[0].value;
-            return argValue.items
-                .filter((expr): expr is ReferenceExpr => isReferenceExpr(expr) && !!getDataModelFieldReference(expr))
-                .map((expr) => expr.target.ref as DataModelField);
-        }
-    }
-    return [];
-}
-
-export function isAuthInvocation(node: AstNode) {
-    return isInvocationExpr(node) && node.function.ref?.name === 'auth' && isFromStdlib(node.function.ref);
-}
-
-export function getDataModelFieldReference(expr: Expression): DataModelField | undefined {
-    if (isReferenceExpr(expr) && isDataModelField(expr.target.ref)) {
-        return expr.target.ref;
-    } else if (isMemberAccessExpr(expr) && isDataModelField(expr.member.ref)) {
-        return expr.member.ref;
-    } else {
-        return undefined;
-    }
 }
 
 export function resolveImportUri(imp: ModelImport): URI | undefined {
@@ -156,7 +111,6 @@ export function getAllDeclarationsFromImports(documents: LangiumDocuments, model
 export function isCollectionPredicate(node: AstNode): node is BinaryExpr {
     return isBinaryExpr(node) && ['?', '!', '^'].includes(node.operator);
 }
-
 
 export function getContainingDataModel(node: Expression): DataModel | undefined {
     let curr: AstNode | undefined = node.$container;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,10 +23,12 @@
         "@prisma/internals-v5": "npm:@prisma/internals@^5.0.0",
         "@zenstackhq/language": "workspace:*",
         "@zenstackhq/runtime": "workspace:*",
+        "langium": "1.2.0",
         "lower-case-first": "^2.0.2",
         "prettier": "^2.8.3 || 3.x",
         "semver": "^7.5.2",
         "ts-morph": "^16.0.0",
+        "ts-pattern": "^4.3.0",
         "upper-case-first": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,6 +4,7 @@ export { generate as generateModelMeta } from './model-meta-generator';
 export * from './policy';
 export * from './prisma';
 export * from './types';
+export * from './typescript-expression-transformer';
 export * from './utils';
 export * from './validation';
 export * from './zmodel-code-generator';

--- a/packages/sdk/src/typescript-expression-transformer.ts
+++ b/packages/sdk/src/typescript-expression-transformer.ts
@@ -17,9 +17,9 @@ import {
     ThisExpr,
     UnaryExpr,
 } from '@zenstackhq/language/ast';
-import { ExpressionContext, getLiteral, isFromStdlib, isFutureExpr } from '@zenstackhq/sdk';
 import { match, P } from 'ts-pattern';
-import { getIdFields } from './ast-utils';
+import { ExpressionContext } from './constants';
+import { getIdFields, getLiteral, isFromStdlib, isFutureExpr } from './utils';
 
 export class TypeScriptExpressionTransformerError extends Error {
     constructor(message: string) {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -22,6 +22,7 @@ import {
     isGeneratorDecl,
     isInvocationExpr,
     isLiteralExpr,
+    isMemberAccessExpr,
     isModel,
     isObjectExpr,
     isReferenceExpr,
@@ -341,7 +342,11 @@ export function getFunctionExpressionContext(funcDecl: FunctionDecl) {
 }
 
 export function isFutureExpr(node: AstNode) {
-    return !!(isInvocationExpr(node) && node.function.ref?.name === 'future' && isFromStdlib(node.function.ref));
+    return isInvocationExpr(node) && node.function.ref?.name === 'future' && isFromStdlib(node.function.ref);
+}
+
+export function isAuthInvocation(node: AstNode) {
+    return isInvocationExpr(node) && node.function.ref?.name === 'auth' && isFromStdlib(node.function.ref);
 }
 
 export function isFromStdlib(node: AstNode) {
@@ -379,4 +384,37 @@ export function getAuthModel(dataModels: DataModel[]) {
         authModel = dataModels.find((m) => m.name === 'User');
     }
     return authModel;
+}
+
+export function getIdFields(dataModel: DataModel) {
+    const fieldLevelId = dataModel.$resolvedFields.find((f) =>
+        f.attributes.some((attr) => attr.decl.$refText === '@id')
+    );
+    if (fieldLevelId) {
+        return [fieldLevelId];
+    } else {
+        // get model level @@id attribute
+        const modelIdAttr = dataModel.attributes.find((attr) => attr.decl?.ref?.name === '@@id');
+        if (modelIdAttr) {
+            // get fields referenced in the attribute: @@id([field1, field2]])
+            if (!isArrayExpr(modelIdAttr.args[0].value)) {
+                return [];
+            }
+            const argValue = modelIdAttr.args[0].value;
+            return argValue.items
+                .filter((expr): expr is ReferenceExpr => isReferenceExpr(expr) && !!getDataModelFieldReference(expr))
+                .map((expr) => expr.target.ref as DataModelField);
+        }
+    }
+    return [];
+}
+
+export function getDataModelFieldReference(expr: Expression): DataModelField | undefined {
+    if (isReferenceExpr(expr) && isDataModelField(expr.target.ref)) {
+        return expr.target.ref;
+    } else if (isMemberAccessExpr(expr) && isDataModelField(expr.member.ref)) {
+        return expr.member.ref;
+    } else {
+        return undefined;
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,9 @@ importers:
       '@zenstackhq/runtime':
         specifier: workspace:*
         version: link:../runtime/dist
+      langium:
+        specifier: 1.2.0
+        version: 1.2.0
       lower-case-first:
         specifier: ^2.0.2
         version: 2.0.2
@@ -632,6 +635,9 @@ importers:
       ts-morph:
         specifier: ^16.0.0
         version: 16.0.0
+      ts-pattern:
+        specifier: ^4.3.0
+        version: 4.3.0
       upper-case-first:
         specifier: ^2.0.2
         version: 2.0.2


### PR DESCRIPTION
- Generate a function to provide value for fields using `auth()` in `@default` so we don't need to evaluate at runtime

    E.g., for model:
    
    ```prisma
    model Post {
        imageUrl String @default(auth().profile.image.url)
    ```
    
    The following function is generated to facilitate the runtime evaluation:
    ```ts
    function $default$Post$imageUrl(user: any) {
        return user?.profile?.image?.url;
    }
    ```

    I think this approach will allow more flexibility in the future, e.g., we may allow calling other functions over `auth()` inside the `@default()`. The existing `TypeScriptExpressionTransformer` class is used to generate the function body. The file needed to be moved to the "@zenstackhq/sdk" package to be accessible. Many other updates in the PR are moving helper functions around too.

- Correct the way of visiting nested create payload

    The `NestedWriteVisistor` is meant to do in-place updates to the payload. I've changed that part of logic, and also added the `createMany` hook.

- Removed logic that turns direct `auth()` usage in `@default()` into stringified text

    I haven't thought about a real-world case this would be useful. Please let me know if you have one in your mind. If we would to support that, the ZModel validation part also needs to be adjusted to allow the type compatibility.
